### PR TITLE
Update descriptions to say "wikis and languages"

### DIFF
--- a/js/public/i18n/en.json
+++ b/js/public/i18n/en.json
@@ -53,7 +53,7 @@
   "dibabel-filters-wiki": "Wiki",
   "dibabel-header-beta--label": "BETA",
   "dibabel-header-beta--tooltip": "Work in progress. Please verify your changes.",
-  "dibabel-header-description": "Keep modules and templates the same across languages. Written by $1",
+  "dibabel-header-description": "Keep modules and templates the same across wikis and languages. Written by $1",
   "dibabel-header-links--bugs": "Bugs & Ideas",
   "dibabel-header-links--help": "Help",
   "dibabel-header-links--source": "Source",


### PR DESCRIPTION
It is also for English Wikipedia and Wikisource, for example,
so it's not just for "languages".