### PR TITLE
Change "saving" to "publishing" in a message

### DIFF
--- a/js/public/i18n/en.json
+++ b/js/public/i18n/en.json
@@ -121,7 +121,7 @@
   "dibabel-updatepage-confirm--tooltip": "Updating wiki page",
   "dibabel-updatepage-confirm--yes": "Yes, do it!",
   "dibabel-updatepage-status": "$1 was updated",
-  "dibabel-updatepage-status-error": "Error saving $1 - $2",
+  "dibabel-updatepage-status-error": "Error publishing $1 - $2",
   "dibabel-user-login": "Login",
   "dibabel-user-login--error": "Unknown user state $1"
 }


### PR DESCRIPTION
"Publishing" is used in most places in MediaWiki for this function.
It is unambigous and says that the page will be indeed published and
not saved in some intermediary storage.